### PR TITLE
Revert "ci(actions): updated tags command to not push to main"

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Push bump commit and tag
         if: steps.bump.outputs.status == '0'
-        run: git push origin --tags
+        run: git push origin main --tags


### PR DESCRIPTION
# Overview

This is no longer necessary - the previous was correct